### PR TITLE
Extrae identificador de Tránsito y Estaciones BCN

### DIFF
--- a/src/sacarIdentificadores.ipynb
+++ b/src/sacarIdentificadores.ipynb
@@ -6,14 +6,12 @@
    "source": [
     "# Código para extraer identificadores de los datasets\n",
     "\n",
-    "### Barcelona\n",
-    "\n",
-    "* Identificador"
+    "### Barcelona"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,12 +23,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comenzamos por el dataset de *Calidad del Aire* de Barcelona, que se trata del dataste correspondiente al mes de Noviembre de 2018"
+    "- 1. Comenzamos por el dataset de *Calidad del Aire* de Barcelona, que se trata del dataset correspondiente al mes de Noviembre de 2018"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -39,7 +37,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -59,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -84,7 +82,7 @@
        "dict"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -124,7 +122,7 @@
        "dict"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +164,7 @@
        "list"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,7 +345,7 @@
    "source": [
     "Parece que el título, en español, se encuentra en el diccionario bajo las `keys`: `title_transalted`, `es`. \n",
     "\n",
-    "Pasamos a mirar cuál de los dos es el que nos interesa y objetenos su `id`."
+    "Pasamos a mirar cuál de los dos es el que nos interesa y obtenemos su `id`."
    ]
   },
   {
@@ -500,6 +498,1276 @@
    "source": [
     "Ya está."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- 2. Continuamos con el dataset de *Tráfico/Estado de tŕansito* de Barcelona, que se trata del dataset correspondiente al mes de Noviembre de 2018:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "urlConsulta = \"http://opendata-ajuntament.barcelona.cat/data/api/3/action/package_search?q=Tramos\"\n",
+    "consulta = requests.get(urlConsulta)\n",
+    "consulta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetsTrafico = json.loads(consulta.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(datasetsTrafico)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "help\n",
+      "success\n",
+      "result\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in datasetsTrafico:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(datasetsTrafico[\"result\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "count\n",
+      "sort\n",
+      "facets\n",
+      "results\n",
+      "search_facets\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in datasetsTrafico[\"result\"]:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(datasetsTrafico[\"result\"][\"results\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsTrafico[\"result\"][\"results\"]:\n",
+    "    print(type(item))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsTrafico[\"result\"][\"results\"]:\n",
+    "    for key in item:\n",
+    "        print(key)\n",
+    "    print(\"--------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsTrafico[\"result\"][\"results\"]:\n",
+    "    for key in item[\"title_translated\"]:\n",
+    "        print(key)\n",
+    "    print(\"--------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Parece que el título, en español, se encuentra en el diccionario bajo las `keys`: `title_transalted`, `es`. \n",
+    "\n",
+    "Pasamos a mirar cuál de los dos es el que nos interesa y obtenemos su `id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, item in enumerate(datasetsTrafico[\"result\"][\"results\"]):\n",
+    "    if item[\"title_translated\"][\"es\"] == \"Información del estado del tránsito en los tramos de la ciudad de Barcelona\":\n",
+    "        print(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'40743bb8-e4e0-457f-aa15-87007a0bdb6a'"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasetTramosBcn = datasetsTrafico[\"result\"][\"results\"][1]\n",
+    "datasetTramosBcn[\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tenemos ya el *id* de los recursos sobre los tramos de tránsito de Barcelona. Ahora estamos interesados en buscar el *id* del que corresponde con el mes de Noviembre de $2018$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 TRAMS.csv\n",
+      "1 2018_05_TRAMS.CSV\n",
+      "2 2018_2T_TRAMS.csv\n",
+      "3 2018_3T_TRAMS.csv\n",
+      "4 2018_4T_TRAMS.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, item in enumerate(datasetTramosBcn[\"resources\"]):\n",
+    "    print(i, item[\"name\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- 3. Continuamos por el dataset de *Estaciones de control* de Barcelona, que se trata del dataset correspondiente al mes de Noviembre de 2018"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "urlConsulta = \"http://opendata-ajuntament.barcelona.cat/data/api/3/action/package_search?q=Estaciones\"\n",
+    "consulta = requests.get(urlConsulta)\n",
+    "consulta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetsEstaciones = json.loads(consulta.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "help\n",
+      "success\n",
+      "result\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in datasetsEstaciones:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "count\n",
+      "sort\n",
+      "facets\n",
+      "results\n",
+      "search_facets\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in datasetsEstaciones[\"result\"]:\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n",
+      "<class 'dict'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsEstaciones[\"result\"][\"results\"]:\n",
+    "    print(type(item))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "extras\n",
+      "--------------------------------\n",
+      "notes_translated\n",
+      "geolocation\n",
+      "code\n",
+      "url_tornada\n",
+      "dataset_fields_description\n",
+      "fuente\n",
+      "private\n",
+      "num_tags\n",
+      "api\n",
+      "frequency\n",
+      "update_string\n",
+      "id\n",
+      "title_translated\n",
+      "metadata_modified\n",
+      "author\n",
+      "author_email\n",
+      "isopen\n",
+      "state\n",
+      "version\n",
+      "observations\n",
+      "relationships_as_object\n",
+      "department\n",
+      "creator_user_id\n",
+      "type\n",
+      "resources\n",
+      "num_resources\n",
+      "tags\n",
+      "fecha_publicacion\n",
+      "load_type\n",
+      "groups\n",
+      "license_id\n",
+      "relationships_as_subject\n",
+      "license_title\n",
+      "organization\n",
+      "name\n",
+      "url\n",
+      "notes\n",
+      "owner_org\n",
+      "tag\n",
+      "license_url\n",
+      "historical\n",
+      "title\n",
+      "revision_id\n",
+      "date_deactivation_informed\n",
+      "--------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsEstaciones[\"result\"][\"results\"]:\n",
+    "    for key in item:\n",
+    "        print(key)\n",
+    "    print(\"--------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n",
+      "ca\n",
+      "en\n",
+      "es\n",
+      "--------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in datasetsEstaciones[\"result\"][\"results\"]:\n",
+    "    for key in item[\"title_translated\"]:\n",
+    "        print(key)\n",
+    "    print(\"--------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Parece que el título, en español, se encuentra en el diccionario bajo las `keys`: `title_transalted`, `es`. \n",
+    "\n",
+    "Pasamos a mirar cuál de los dos es el que nos interesa y obtenemos su `id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, item in enumerate(datasetsEstaciones[\"result\"][\"results\"]):\n",
+    "    if item[\"title_translated\"][\"es\"] == \"Estaciones de medida de la calidad del aire de la ciudad de Barcelona\":\n",
+    "        print(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'4dff88b1-151b-48db-91c2-45007cd5d07a'"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasetEstacionesBcn = datasetsEstaciones[\"result\"][\"results\"][1]\n",
+    "datasetEstacionesBcn[\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tenemos ya el *id* de los recursos sobre las estaciones de control de aire de Barcelona. Ahora estamos interesados en buscar el *id* del que corresponde con el mes de Noviembre de $2018$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 qualitat_aire_estacions_bcn.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, item in enumerate(datasetEstacionesBcn[\"resources\"]):\n",
+    "    print(i, item[\"name\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'6c33f60b-2f52-4954-a5e6-cf879890551c'"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasetCalidadBcnNov = datasetEstacionesBcn[\"resources\"][0]\n",
+    "datasetCalidadBcnNov[\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hemos obtenido el identificador para el dataset de Estaciones de aire de Barcelona."
+   ]
   }
  ],
  "metadata": {
@@ -518,7 +1786,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Se ha añadido código para los dataset de Tránsito/Tráfico de Barcelona y para las Estaciones de aire de Barcelona
NOTA: Revisar código para el dataset de Tránsito (no encuentra el identificador de nuestro dataset sino de otro)